### PR TITLE
small regex fix: we do not want keywords to be triggered accidentally…

### DIFF
--- a/keanu_bot.py
+++ b/keanu_bot.py
@@ -96,7 +96,7 @@ def main():
     )
     dp.add_handler(
         MessageHandler(
-            Filters.regex("(?i)(mac|win|apple)"),
+            Filters.regex("(?i)( mac | win | apple )"),
             callback=sucks_handler,
         )
     )


### PR DESCRIPTION
… (i.e. cicamaca should not trigger 'mac' keyword)